### PR TITLE
Prevent DoS by using timeouts in HTTP calls

### DIFF
--- a/hibp.go
+++ b/hibp.go
@@ -4,9 +4,23 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"strings"
+	"time"
 )
+
+var HttpClient = &http.Client{
+	Transport: &http.Transport{
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	},
+}
 
 func foundInHIBP(s string) error {
 	h := sha1.New()
@@ -18,7 +32,7 @@ func foundInHIBP(s string) error {
 
 	url := "https://api.pwnedpasswords.com/range/" + firstFive
 
-	resp, err := http.Get(url)
+	resp, err := HttpClient.Get(url)
 	if err != nil {
 		return err
 	}

--- a/hibp.go
+++ b/hibp.go
@@ -4,9 +4,20 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"strings"
+	"time"
 )
+
+var HttpClient = &http.Client{
+	Transport: &http.Transport{
+		Dial: (&net.Dialer{
+			Timeout: 30 * time.Second,
+		}).Dial,
+		ResponseHeaderTimeout: 10 * time.Second,
+	},
+}
 
 func foundInHIBP(s string) error {
 	h := sha1.New()
@@ -18,7 +29,7 @@ func foundInHIBP(s string) error {
 
 	url := "https://api.pwnedpasswords.com/range/" + firstFive
 
-	resp, err := http.Get(url)
+	resp, err := HttpClient.Get(url)
 	if err != nil {
 		return err
 	}

--- a/hibp_go1.6.go
+++ b/hibp_go1.6.go
@@ -1,4 +1,5 @@
 // +build go1.6
+
 package crunchy
 
 import (

--- a/hibp_go1.6.go
+++ b/hibp_go1.6.go
@@ -1,0 +1,20 @@
+// +build go1.6
+package crunchy
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+func init() {
+	HttpClient.Transport = &http.Transport{
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}


### PR DESCRIPTION
The default HTTP client does not enforce any timeouts. This task is left to the user. Not doing so leaves one vulnerable to denial of service attacks. 
A more probable scenario might be a downtime of HIBP and hanging / blocking programs using crunchy.

The HttpClient variable is exported to enable users to change the default timeouts