### PR TITLE
Reduce memory footprint indexing dictionaries

### DIFF
--- a/crunchy.go
+++ b/crunchy.go
@@ -8,8 +8,9 @@
 package crunchy
 
 import (
+	"bufio"
 	"hash"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -84,13 +85,15 @@ func (v *Validator) indexDictionaries() {
 	}
 
 	for _, dict := range dicts {
-		buf, err := ioutil.ReadFile(dict)
+		file, err := os.Open(dict)
 		if err != nil {
 			continue
 		}
+		defer file.Close()
 
-		for _, word := range strings.Split(string(buf), "\n") {
-			nw := normalize(word)
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			nw := normalize(scanner.Text())
 			nwlen := len(nw)
 			if nwlen > v.wordsMaxLen {
 				v.wordsMaxLen = nwlen

--- a/crunchy.go
+++ b/crunchy.go
@@ -9,6 +9,7 @@ package crunchy
 
 import (
 	"bufio"
+	"encoding/hex"
 	"hash"
 	"os"
 	"path/filepath"
@@ -132,8 +133,10 @@ func (v *Validator) foundInDictionaries(s string) error {
 	}
 
 	// find hashed dictionary entries
-	if word, ok := v.hashedWords[pw]; ok {
-		return &HashedDictionaryError{ErrHashedDictionary, word}
+	if pwindex, err := hex.DecodeString(pw); err == nil {
+		if word, ok := v.hashedWords[string(pwindex)]; ok {
+			return &HashedDictionaryError{ErrHashedDictionary, word}
+		}
 	}
 
 	// find mangled / reversed passwords

--- a/stringutils.go
+++ b/stringutils.go
@@ -8,7 +8,6 @@
 package crunchy
 
 import (
-	"encoding/hex"
 	"hash"
 	"strings"
 	"unicode"
@@ -68,5 +67,5 @@ func normalize(s string) string {
 func hashsum(s string, hasher hash.Hash) string {
 	hasher.Reset()
 	hasher.Write([]byte(s))
-	return hex.EncodeToString(hasher.Sum(nil))
+	return string(hasher.Sum(nil))
 }


### PR DESCRIPTION
This is a preliminary attempt to reduce crunchy's memory footprint when used with very large dictionary files.

Started as https://github.com/gopasspw/gopass/issues/1261