### PR TITLE
Use concurrency to check mangled passwords

### DIFF
--- a/crunchy_test.go
+++ b/crunchy_test.go
@@ -128,12 +128,27 @@ func TestCheckHIBP(t *testing.T) {
 	}
 }
 
+func BenchmarkIndexDictionaries(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		v := NewValidatorWithOpts(Options{
+			MinDist:        -1,
+			Hashers:        []hash.Hash{md5.New(), sha1.New(), sha256.New(), sha512.New()},
+			DictionaryPath: "/usr/share/dict",
+		})
+
+		v.indexDictionaries()
+	}
+
+}
+
 func BenchmarkValidatePassword(b *testing.B) {
 	v := NewValidatorWithOpts(Options{
 		MinDist:        -1,
 		Hashers:        []hash.Hash{md5.New(), sha1.New(), sha256.New(), sha512.New()},
 		DictionaryPath: "/usr/share/dict",
 	})
+	v.once.Do(v.indexDictionaries)
+	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
 		_ = v.Check(pass.valid)

--- a/crunchy_test.go
+++ b/crunchy_test.go
@@ -13,16 +13,25 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"hash"
-	"strconv"
 	"testing"
 )
 
 var (
+	// example of valid and invalid passwords
+	pass = struct {
+		valid   string
+		invalid string
+	}{"d1924ce3d0510b2b2b4604c99453e2e1", ""}
+
 	pws = []struct {
 		pw       string
 		expected error
 		rating   uint
 	}{
+		// include values from pass in tests
+		{pass.valid, nil, 100},
+		{pass.invalid, ErrEmpty, 0},
+
 		// valid passwords
 		{"d1924ce3d0510b2b2b4604c99453e2e1", nil, 100},
 		{"aCgIknPv", nil, 40},
@@ -120,10 +129,13 @@ func TestCheckHIBP(t *testing.T) {
 }
 
 func BenchmarkValidatePassword(b *testing.B) {
-	v := NewValidator()
-	s := hashsum(strconv.Itoa(b.N), md5.New())
+	v := NewValidatorWithOpts(Options{
+		MinDist:        -1,
+		Hashers:        []hash.Hash{md5.New(), sha1.New(), sha256.New(), sha512.New()},
+		DictionaryPath: "/usr/share/dict",
+	})
 
 	for n := 0; n < b.N; n++ {
-		_ = v.Check(s)
+		_ = v.Check(pass.valid)
 	}
 }

--- a/crunchy_test.go
+++ b/crunchy_test.go
@@ -154,3 +154,14 @@ func BenchmarkValidatePassword(b *testing.B) {
 		_ = v.Check(pass.valid)
 	}
 }
+
+func BenchmarkFoundInDictionaries(b *testing.B) {
+	v := NewValidator()
+	v.once.Do(v.indexDictionaries)
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		_ = v.foundInDictionaries(pass.valid)
+	}
+
+}


### PR DESCRIPTION
This is part of an attempt to improve crunchy's performance.

This PR focuses on improving the mangled password checks by using concurrency to speed up the search.
```
$ benchstat before after 
name                   old time/op  new time/op  delta
ValidatePassword-8      41.3s ± 1%   29.7s ± 1%  -28.12%  (p=0.000 n=8+8)
FoundInDictionaries-8   11.8s ± 1%    4.4s ± 1%  -62.24%  (p=0.000 n=8+8)
```


Hashing will be next