### PR TITLE
Add MustContainDigit and MustContainSymbol flags to the Option struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-crunchy
-=======
+# crunchy
 
 [![Latest Release](https://img.shields.io/github/release/muesli/crunchy.svg)](https://github.com/muesli/crunchy/releases)
 [![GoDoc](https://godoc.org/github.com/golang/gddo?status.svg)](https://godoc.org/github.com/muesli/crunchy)
@@ -10,14 +9,17 @@ crunchy
 Finds common flaws in passwords. Like cracklib, but written in Go.
 
 Detects:
- - `ErrEmpty`: Empty passwords
- - `ErrTooShort`: Too short passwords
- - `ErrTooFewChars`: Too few different characters, like "aabbccdd"
- - `ErrTooSystematic`: Systematic passwords, like "abcdefgh" or "87654321"
- - `ErrDictionary`: Passwords from a dictionary / wordlist
- - `ErrMangledDictionary`: Mangled / reversed passwords, like "p@ssw0rd" or "drowssap"
- - `ErrHashedDictionary`: Hashed dictionary words, like "5f4dcc3b5aa765d61d8327deb882cf99" (the md5sum of "password")
- - `ErrFoundHIBP`: Optional hash checks against the haveibeenpwned.com database
+
+- `ErrEmpty`: Empty passwords
+- `ErrTooShort`: Too short passwords
+- `ErrTooFewChars`: Too few different characters, like "aabbccdd"
+- `ErrNoDigits`: Password does not contain any digits
+- `ErrNoDigits`: Password does not contain any digits
+- `ErrTooSystematic`: Systematic passwords, like "abcdefgh" or "87654321"
+- `ErrDictionary`: Passwords from a dictionary / wordlist
+- `ErrMangledDictionary`: Mangled / reversed passwords, like "p@ssw0rd" or "drowssap"
+- `ErrHashedDictionary`: Hashed dictionary words, like "5f4dcc3b5aa765d61d8327deb882cf99" (the md5sum of "password")
+- `ErrFoundHIBP`: Optional hash checks against the haveibeenpwned.com database
 
 Your system dictionaries from `/usr/share/dict` will be indexed. If no dictionaries were found, crunchy only relies on
 the regular sanity checks (`ErrEmpty`, `ErrTooShort`, `ErrTooFewChars` and `ErrTooSystematic`). On Ubuntu it is
@@ -97,6 +99,14 @@ func main() {
         // DictionaryPath contains all the dictionaries that will be parsed
         // (default is /usr/share/dict)
         DictionaryPath: "/var/my/own/dicts",
+
+        // MustContainDigit is a flag to require at least one digit for a valid password
+        // (default is false)
+        MustContainDigit: true,
+
+        // MustContainSymbol is a flag to require at least one special symbol for a valid password
+        // (default is false)
+        MustContainDigit: true,
 
 	// Check haveibeenpwned.com database
 	// Default is false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# crunchy
+crunchy
 =======
+
 [![Latest Release](https://img.shields.io/github/release/muesli/crunchy.svg)](https://github.com/muesli/crunchy/releases)
 [![GoDoc](https://godoc.org/github.com/golang/gddo?status.svg)](https://godoc.org/github.com/muesli/crunchy)
 [![Build Status](https://travis-ci.org/muesli/crunchy.svg?branch=master)](https://travis-ci.org/muesli/crunchy)
@@ -9,16 +10,16 @@
 Finds common flaws in passwords. Like cracklib, but written in Go.
 
 Detects:
-- `ErrEmpty`: Empty passwords
-- `ErrTooShort`: Too short passwords
-- `ErrTooFewChars`: Too few different characters, like "aabbccdd"
-- `ErrNoDigits`: Password does not contain any digits
-- `ErrNoDigits`: Password does not contain any digits
-- `ErrTooSystematic`: Systematic passwords, like "abcdefgh" or "87654321"
-- `ErrDictionary`: Passwords from a dictionary / wordlist
-- `ErrMangledDictionary`: Mangled / reversed passwords, like "p@ssw0rd" or "drowssap"
-- `ErrHashedDictionary`: Hashed dictionary words, like "5f4dcc3b5aa765d61d8327deb882cf99" (the md5sum of "password")
-- `ErrFoundHIBP`: Optional hash checks against the haveibeenpwned.com database
+ - `ErrEmpty`: Empty passwords
+ - `ErrTooShort`: Too short passwords
+ - `ErrNoDigits`: Password does not contain any digits
+ - `ErrNoSymbols`: Password does not contain any special characters
+ - `ErrTooFewChars`: Too few different characters, like "aabbccdd"
+ - `ErrTooSystematic`: Systematic passwords, like "abcdefgh" or "87654321"
+ - `ErrDictionary`: Passwords from a dictionary / wordlist
+ - `ErrMangledDictionary`: Mangled / reversed passwords, like "p@ssw0rd" or "drowssap"
+ - `ErrHashedDictionary`: Hashed dictionary words, like "5f4dcc3b5aa765d61d8327deb882cf99" (the md5sum of "password")
+ - `ErrFoundHIBP`: Optional hash checks against the haveibeenpwned.com database
 
 Your system dictionaries from `/usr/share/dict` will be indexed. If no dictionaries were found, crunchy only relies on
 the regular sanity checks (`ErrEmpty`, `ErrTooShort`, `ErrTooFewChars` and `ErrTooSystematic`). On Ubuntu it is
@@ -105,7 +106,7 @@ func main() {
 
         // MustContainSymbol is a flag to require at least one special symbol for a valid password
         // (default is false)
-        MustContainDigit: true,
+        MustContainSymbol: true,
 
 	// Check haveibeenpwned.com database
 	// Default is false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # crunchy
-
+=======
 [![Latest Release](https://img.shields.io/github/release/muesli/crunchy.svg)](https://github.com/muesli/crunchy/releases)
 [![GoDoc](https://godoc.org/github.com/golang/gddo?status.svg)](https://godoc.org/github.com/muesli/crunchy)
 [![Build Status](https://travis-ci.org/muesli/crunchy.svg?branch=master)](https://travis-ci.org/muesli/crunchy)
@@ -9,7 +9,6 @@
 Finds common flaws in passwords. Like cracklib, but written in Go.
 
 Detects:
-
 - `ErrEmpty`: Empty passwords
 - `ErrTooShort`: Too short passwords
 - `ErrTooFewChars`: Too few different characters, like "aabbccdd"

--- a/crunchy.go
+++ b/crunchy.go
@@ -175,6 +175,20 @@ func (v *Validator) Check(password string) error {
 		return ErrTooFewChars
 	}
 
+	if v.options.MustContainDigit {
+		validateDigit := regexp.MustCompile(`[0-9]+`)
+		if !validateDigit.MatchString(password) {
+			return ErrNoDigits
+		}
+	}
+
+	if v.options.MustContainSymbol {
+		validateSymbols := regexp.MustCompile(`[^\w\s]+`)
+		if !validateSymbols.MatchString(password) {
+			return ErrNoSymbols
+		}
+	}
+
 	// Inspired by cracklib
 	maxrepeat := 3.0 + (0.09 * float64(len(password)))
 	if countSystematicChars(password) > int(maxrepeat) {
@@ -190,20 +204,6 @@ func (v *Validator) Check(password string) error {
 		err := foundInHIBP(password)
 		if err != nil {
 			return err
-		}
-	}
-
-	if v.options.MustContainDigit {
-		validateDigit := regexp.MustCompile(`[0-9]+`)
-		if !validateDigit.MatchString(password) {
-			return ErrNoDigits
-		}
-	}
-
-	if v.options.MustContainSymbol {
-		validateSymbols := regexp.MustCompile(`[^\w\s]+`)
-		if !validateSymbols.MatchString(password) {
-			return ErrNoSymbols
 		}
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -39,6 +39,10 @@ var (
 	ErrTooShort = errors.New("Password is too short")
 	// ErrTooFewChars gets returned when the password does not contain enough unique characters
 	ErrTooFewChars = errors.New("Password does not contain enough different/unique characters")
+	// ErrNoDigits gets returned when the password does not contain any digits
+	ErrNoDigits = errors.New("Password does not contain any digits")
+	// ErrNoSymbols gets returned when the password does not contain any symbols
+	ErrNoSymbols = errors.New("Password does not contain any special symbols")
 	// ErrTooSystematic gets returned when the password is too systematic (e.g. 123456, abcdef)
 	ErrTooSystematic = errors.New("Password is too systematic")
 	// ErrDictionary gets returned when the password is found in a dictionary


### PR DESCRIPTION
This PR extends the crunchy.Options struct to improve the password requirements options.
Two new flags are added: 
`MustContainDigit` -  if set to true, the password must contain at least one digit to be valid. (default is false)
`MustContainSymbol` - if set to true, the password must contain to contain at least one special symbol to be valid. (default is false)
