### PR TITLE
Remove defer Statement

### DIFF
--- a/crunchy.go
+++ b/crunchy.go
@@ -97,7 +97,6 @@ func (v *Validator) indexDictionaries() {
 		if err != nil {
 			continue
 		}
-		defer file.Close()
 
 		scanner := bufio.NewScanner(file)
 		for scanner.Scan() {
@@ -117,6 +116,8 @@ func (v *Validator) indexDictionaries() {
 				v.hashedWords[hashsum(nw, hasher)] = nw
 			}
 		}
+
+		file.Close()
 	}
 }
 


### PR DESCRIPTION
This small patch removes a defer statement inside of a for loop and calls `Close` after the scanner is done reading the file.