### PR TITLE
Change deprecated func calls

### DIFF
--- a/hibp.go
+++ b/hibp.go
@@ -3,7 +3,7 @@ package crunchy
 import (
 	"crypto/sha1"
 	"encoding/hex"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -12,9 +12,9 @@ import (
 
 var HttpClient = &http.Client{
 	Transport: &http.Transport{
-		Dial: (&net.Dialer{
+		DialContext: (&net.Dialer{
 			Timeout: 30 * time.Second,
-		}).Dial,
+		}).DialContext,
 		ResponseHeaderTimeout: 10 * time.Second,
 	},
 }
@@ -36,7 +36,7 @@ func foundInHIBP(s string) error {
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/hibp_go1.6.go
+++ b/hibp_go1.6.go
@@ -1,3 +1,4 @@
+//go:build go1.6
 // +build go1.6
 
 package crunchy
@@ -10,10 +11,10 @@ import (
 
 func init() {
 	HttpClient.Transport = &http.Transport{
-		Dial: (&net.Dialer{
+		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
-		}).Dial,
+		}).DialContext,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ResponseHeaderTimeout: 10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,

--- a/stringutils.go
+++ b/stringutils.go
@@ -66,6 +66,6 @@ func normalize(s string) string {
 // hashsum returns the hashed sum of a string
 func hashsum(s string, hasher hash.Hash) string {
 	hasher.Reset()
-	_, _ = hasher.Write([]byte(s))
+	hasher.Write([]byte(s))
 	return string(hasher.Sum(nil))
 }


### PR DESCRIPTION
Change deprecated `ioutil.ReadAll` to `io.ReadAll`
Change deprecated `Dial` to `DialContext`

Small change to remove unnecessary attribution 💅🏻 